### PR TITLE
Feature/npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,8 @@ To get this project working from a virgin Windows Machine perform the following 
 Go to https://nodejs.org/en/download/ and download the appropriate version for the Windows Version (32/64 bit)
 This app has been tested with Node JS Version v6.6.0
 
-
-## Install Gulp
-Open a command prompt (I'd recommend installing [ConsoleZ](https://github.com/cbucher/console/wiki/Downloads) )
-From the command prompt (in any folder) use npm to install gulp globally:<br>
-**C:>npm install -g gulp**
-
 ## Establish Node Path environment variable
+Open a command prompt (I'd recommend installing [ConsoleZ](https://github.com/cbucher/console/wiki/Downloads) )
 - Create an environmental variable called NODE_PATH
 - Set it to: %AppData%\npm\node_modules
 - Close CMD, and Re-Open to get the new ENV variables
@@ -23,8 +18,10 @@ From the command prompt (in the project folder) use npm to install the project d
 **C:\My_New_Project>npm install**
 
 ##Run gulp
-From the command prompt (in the project folder) run the gulp command
-**C:\My_New_Project>gulp**
+From the command prompt (in the project folder) use npm to run the gulp command
+**C:\My_New_Project>npm run gulp**
+
+You can use `npm run` to find a list of other tasks to run, such as `npm start` which spins up the server or `npm run lint` to run the code linter.
 
 ##Execute various tasks
 [14:19:04] Using gulpfile C:\My_New_Project\gulpfile.js<br>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const gulp = require("gulp");
 const request = require("request");
 const inquirer = require("inquirer");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,8 +196,8 @@ gulp.task("logging", function(){
     logging(); 
 });
 
-gulp.task("post", function(done = function() {console.log("Done?")}){ 
-    PostWithData(done); 
+gulp.task("post", function(){
+    PostWithData();
 });
 
 gulp.task("postND", function(){ 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "a Node.js project that provides an endpoint to process the Package#0 Header specified in 7.1.1.1 of the OMA-TS-DM Protocol.  When the endpoint receives a POST request containing that binary package, it should respond with a 200 status and a body containing json indicating the version and option count values. The response should look similar to this:",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "gulp": "gulp",
+    "lint": "gulp lint",
+    "start": "gulp run:server"
   },
   "author": "barlowm@gmail.com",
   "license": "MIT",

--- a/src/controller/genHeader.js
+++ b/src/controller/genHeader.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     genHeader : function (headerInfo) {
         let Version = headerInfo.ver;   // Version = 4 bits from 0 - 15, 10 = 1010

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const express = require('express');
 const Controller = require('../controller/controller');
 

--- a/tests/test2.js
+++ b/tests/test2.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // tests/test2.js
 // let chai = require('chai');
 // let chaiHttp = require('chai-http');


### PR DESCRIPTION
Here are the changes needed to setup the npm run scripts. You already had gulp listed in `package.json` so you were making your users install it twice, once locally to `node_wip/node_modules` and again globally. I added a few scripts to give you an idea of how they work:
- `npm run gulp` is your default gulp task, the same as running `gulp` before. but npm is looking to its local version of gulp rather than the global one so your project dependency won't conflict with anyone else's.
- `npm run lint` is your lint task, the same as running `gulp lint` or running `gulp` and selecting it from your prompt.
- `npm start` spins up your server, just like `gulp run:server` or `gulp` and selecting "Forever" in the prompt. this task is special. you don't have to type `run`. there are a select few of these reserved script names, check the docs for a full list.

In addition to adding the scripts, I went ahead and updated the docs too. I also had to fix a few errors that were preventing me from running your original gulp task. Not sure why it worked for you and not for me.

Anywho, hope that helps!
